### PR TITLE
Fixed rotation class to use 0-360 degree range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ TombEngine releases are located in this repository (alongside with Tomb Editor):
 * Renamed `Input.KeyIsHit` and `Input.KeyIsHeld` to `Input.IsKeyHit` and `Input.IsKeyHeld`.
 * Updated `Input.IsKeyHeld` with additional parameter indicating key hold delay.
 * Updated `Effects.MakeExplosion` and `Effects.EmitBlood` to spawn correct effects when used underwater.
+* Fixed `Rotation` class to use unsigned 0-360 degree range, and provide `Rotation:Signed` method to get legacy -180-180 range.
 * Fixed `Moveable.GetJointPosition` not returning correct results if moveable is invisible or not rendered.
 * Fixed `Util.PickMoveableByDisplayPosition`.
 

--- a/Documentation/doc/3 primitive classes/Rotation.html
+++ b/Documentation/doc/3 primitive classes/Rotation.html
@@ -118,22 +118,22 @@
 
 <h1>Primitive Class <code>Rotation</code></h1>
 <p>Represents a 3D rotation.</p>
-<p> All angle components are in degrees clamped to the range [0.0, 360.0].</p>
+<p> All angle components are in degrees, automatically clamped to the range [0, 360], excluding raw access.</p>
 
 
 <h2><a href="#Members">Members</a></h2>
 <table class="function_list">
 	<tr>
 	<td class="name" ><a href="#x">x</a></td>
-	<td class="summary">(float) X angle component in degrees.</td>
+	<td class="summary">(float) Raw X angle component in degrees.</td>
 	</tr>
 	<tr>
 	<td class="name" ><a href="#y">y</a></td>
-	<td class="summary">(float) Y angle component in degrees.</td>
+	<td class="summary">(float) Raw Y angle component in degrees.</td>
 	</tr>
 	<tr>
 	<td class="name" ><a href="#z">z</a></td>
-	<td class="summary">(float) Z angle component in degrees.</td>
+	<td class="summary">(float) Raw Z angle component in degrees.</td>
 	</tr>
 </table>
 <h2><a href="#Functions">Functions</a></h2>
@@ -149,6 +149,10 @@
 	<tr>
 	<td class="name" ><a href="#Direction">Direction()</a></td>
 	<td class="summary">Get the normalized direction vector of this Rotation.</td>
+	</tr>
+	<tr>
+	<td class="name" ><a href="#Signed">Signed()</a></td>
+	<td class="summary">Get the signed version of this Rotation, clamped to [-180, 180].</td>
 	</tr>
 	<tr>
 	<td class="name" ><a href="#__tostring">__tostring(rot)</a></td>
@@ -170,7 +174,7 @@
     <strong>x</strong>
     </dt>
     <dd>
-    (float) X angle component in degrees.
+    (float) Raw X angle component in degrees.  Does not automaticaly clamp to [0, 360].
 
 
 
@@ -185,7 +189,7 @@
     <strong>y</strong>
     </dt>
     <dd>
-    (float) Y angle component in degrees.
+    (float) Raw Y angle component in degrees.  Does not automaticaly clamp to [0, 360].
 
 
 
@@ -200,7 +204,7 @@
     <strong>z</strong>
     </dt>
     <dd>
-    (float) Z angle component in degrees.
+    (float) Raw Z angle component in degrees.  Does not automaticaly clamp to [0, 360].
 
 
 
@@ -297,6 +301,27 @@
 
            <span class="types"><a class="type" href="../3 primitive classes/Vec3.html#">Vec3</a></span>
         Normalized direction vector.
+    </ol>
+
+
+
+
+</dd>
+    <dt>
+    <a name = "Signed"></a>
+    <strong>Signed()</strong>
+    </dt>
+    <dd>
+    Get the signed version of this Rotation, clamped to [-180, 180].
+
+
+
+
+    <h3>Returns:</h3>
+    <ol>
+
+           <span class="types"><a class="type" href="../3 primitive classes/Rotation.html#">Rotation</a></span>
+        Signed rotation.
     </ol>
 
 

--- a/TombEngine/Scripting/Internal/ReservedScriptNames.h
+++ b/TombEngine/Scripting/Internal/ReservedScriptNames.h
@@ -516,6 +516,7 @@ constexpr char ScriptReserved_StaticShatter[]		= "Shatter";
 constexpr char ScriptReserved_Rotation[]			= "Rotation";
 constexpr char ScriptReserved_RotationDirection[]	= "Direction";
 constexpr char ScriptReserved_RotationLerp[]		= "Lerp";
+constexpr char ScriptReserved_RotationSigned[]		= "Signed";
 
 // Vec2
 

--- a/TombEngine/Scripting/Internal/TEN/Types/Rotation/Rotation.cpp
+++ b/TombEngine/Scripting/Internal/TEN/Types/Rotation/Rotation.cpp
@@ -9,7 +9,7 @@ using namespace TEN::Math;
 namespace TEN::Scripting
 {
 	/// Represents a 3D rotation.
-	// All angle components are in degrees clamped to the range [0.0, 360.0].
+	// All angle components are in degrees, automatically clamped to the range [0, 360], excluding raw access.
 	// @tenprimitive Rotation
 	// @pragma nostrip
 
@@ -32,16 +32,17 @@ namespace TEN::Scripting
 			// Utilities
 			ScriptReserved_RotationLerp, &Rotation::Lerp,
 			ScriptReserved_RotationDirection, &Rotation::Direction,
+			ScriptReserved_RotationSigned, &Rotation::Signed,
 
-			/// (float) X angle component in degrees.
+			/// (float) Raw X angle component in degrees. Does not automaticaly clamp to [0, 360].
 			// @mem x
 			"x", &Rotation::x,
 
-			/// (float) Y angle component in degrees.
+			/// (float) Raw Y angle component in degrees. Does not automaticaly clamp to [0, 360].
 			// @mem y
 			"y", &Rotation::y,
 
-			/// (float) Z angle component in degrees.
+			/// (float) Raw Z angle component in degrees. Does not automaticaly clamp to [0, 360].
 			// @mem z
 			"z", &Rotation::z);
 	}
@@ -54,23 +55,23 @@ namespace TEN::Scripting
 	// @treturn Rotation A new Rotation object.
 	Rotation::Rotation(float x, float y, float z)
 	{
-		this->x = x;
-		this->y = y;
-		this->z = z;
+		this->x = WrapToUnsignedAngle(x);
+		this->y = WrapToUnsignedAngle(y);
+		this->z = WrapToUnsignedAngle(z);
 	}
 
 	Rotation::Rotation(const Vector3& vec)
 	{
-		x = vec.x;
-		y = vec.y;
-		z = vec.z;
+		x = WrapToUnsignedAngle(vec.x);
+		y = WrapToUnsignedAngle(vec.y);
+		z = WrapToUnsignedAngle(vec.z);
 	}
 
 	Rotation::Rotation(const EulerAngles& eulers)
 	{
-		x = TO_DEGREES(eulers.x);
-		y = TO_DEGREES(eulers.y);
-		z = TO_DEGREES(eulers.z);
+		x = WrapToUnsignedAngle(TO_DEGREES(eulers.x));
+		y = WrapToUnsignedAngle(TO_DEGREES(eulers.y));
+		z = WrapToUnsignedAngle(TO_DEGREES(eulers.z));
 	}
 
 	/// Get the linearly interpolated Rotation between this Rotation and the input Rotation according to the input alpha.
@@ -94,6 +95,18 @@ namespace TEN::Scripting
 		return Vec3(eulers.ToDirection());
 	}
 
+	/// Get the signed version of this Rotation, clamped to [-180, 180].
+	// @function Signed
+	// @treturn Rotation Signed rotation.
+	Rotation Rotation::Signed() const
+	{
+		auto signedRot = Rotation();
+		signedRot.x = WrapToSignedAngle(x);
+		signedRot.y = WrapToSignedAngle(y);
+		signedRot.z = WrapToSignedAngle(z);
+		return signedRot;
+	}
+
 	/// @function __tostring
 	// @tparam Rotation rot This Rotation.
 	// @treturn string A string showing the X, Y, and Z angle components of this Rotation.
@@ -114,38 +127,47 @@ namespace TEN::Scripting
 
 	bool Rotation::operator ==(const Rotation& rot) const
 	{
-		return (rot.x == x && rot.y == y && rot.z == z);
+		return (WrapToUnsignedAngle(rot.x) == WrapToUnsignedAngle(x) &&
+				WrapToUnsignedAngle(rot.y) == WrapToUnsignedAngle(y) &&
+				WrapToUnsignedAngle(rot.z) == WrapToUnsignedAngle(z));
 	}
 
 	Rotation Rotation::operator +(const Rotation& rot) const
 	{
-		return Rotation(WrapAngle(x + rot.x), WrapAngle(y + rot.y), WrapAngle(z + rot.z));
+		return Rotation(WrapToUnsignedAngle(x + rot.x), WrapToUnsignedAngle(y + rot.y), WrapToUnsignedAngle(z + rot.z));
 	}
 
 	Rotation Rotation::operator -(const Rotation& rot) const
 	{
-		return Rotation(WrapAngle(x - rot.x), WrapAngle(y - rot.y), WrapAngle(z - rot.z));
+		return Rotation(WrapToUnsignedAngle(x - rot.x), WrapToUnsignedAngle(y - rot.y), WrapToUnsignedAngle(z - rot.z));
 	}
 
 	Rotation& Rotation::operator +=(const Rotation& rot)
 	{
-		x = WrapAngle(x + rot.x);
-		y = WrapAngle(y + rot.y);
-		z = WrapAngle(z + rot.z);
+		x = WrapToUnsignedAngle(x + rot.x);
+		y = WrapToUnsignedAngle(y + rot.y);
+		z = WrapToUnsignedAngle(z + rot.z);
 		return *this;
 	}
 
 	Rotation& Rotation::operator -=(const Rotation& rot)
 	{
-		x = WrapAngle(x - rot.x);
-		y = WrapAngle(y - rot.y);
-		z = WrapAngle(z - rot.z);
+		x = WrapToUnsignedAngle(x - rot.x);
+		y = WrapToUnsignedAngle(y - rot.y);
+		z = WrapToUnsignedAngle(z - rot.z);
 		return *this;
 	}
 
-	float Rotation::WrapAngle(float angle) const
+	float Rotation::WrapToUnsignedAngle(float angle) const
 	{
 		angle -= std::floor(angle / 360.0f) * 360.0f;
 		return ((angle < 0.0f) ? (angle + 360.0f) : angle);
+	}
+	
+	float Rotation::WrapToSignedAngle(float angle) const
+	{
+		// Wrap to a signed angle first to clamp extra rotation loops.
+		auto result = WrapToUnsignedAngle(angle);
+		return (result > 180.0f) ? result - 360.0f : result;
 	}
 }

--- a/TombEngine/Scripting/Internal/TEN/Types/Rotation/Rotation.h
+++ b/TombEngine/Scripting/Internal/TEN/Types/Rotation/Rotation.h
@@ -30,6 +30,7 @@ namespace TEN::Scripting
 		// Utilities
 
 		Rotation Lerp(const Rotation& rot, float alpha) const;
+		Rotation Signed() const;
 		Vec3	 Direction() const;
 
 		// Converters
@@ -50,6 +51,7 @@ namespace TEN::Scripting
 	private:
 		// Helpers
 
-		float WrapAngle(float angle) const;
+		float WrapToUnsignedAngle(float angle) const;
+		float WrapToSignedAngle(float angle) const;
 	};
 }


### PR DESCRIPTION
## Checklist

- [x] I have added a changelog entry to CHANGELOG.md file on the branch/fork (if it is an internal change then it is not needed) 
- [x] Pull request meets the Coding Conventions standards: https://github.com/MontyTRC89/TombEngine/blob/master/CONTRIBUTING.md#coding-conventions

## Links to issue(s) this pull request concerns (if applicable)

N/A

## Description of pull request 

Fixes an issue with `Rotation` class, which was using non-intuitive range from -180 degrees to 180 degrees instead of 0-360 degrees. Additionally implements `Rotation:Signed()` method which returns signed angle, in case it is still needed. Also corrects and introduces angle wrapping where it is needed.