### PR TITLE
Object targeting occlusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ TombEngine releases are located in this repository (alongside with Tomb Editor):
 * Fixed dying while landing into shallow water after freefall.
 * Fixed shotgun wideshot ammo having same accuracy as normal ammo.
 * Fixed projectiles sometimes flying through narrow room geometry corners.
+* Fixed original game issue where enemies could be targeted through objects and static meshes.
 * Fixed dynamic lights disappearing for a single frame after exiting game menus.
 * Fixed controls being stuck when engine window is out of focus.
 * Fixed intense GPU usage when engine window is minimized.

--- a/Scripts/Settings.lua
+++ b/Scripts/Settings.lua
@@ -26,6 +26,8 @@ local settings = Flow.Settings.new()
 	settings.Flare.flicker = true
 	settings.Flare.pickupCount = 12
 	
+	settings.Gameplay.targetObjectOcclusion = true
+	
 	settings.Graphics.skinning = true
 	
 	settings.Hud.statusBars = true

--- a/TombEngine/Game/Lara/lara_fire.cpp
+++ b/TombEngine/Game/Lara/lara_fire.cpp
@@ -937,6 +937,9 @@ bool IsTargetOccludedByObjects(ItemInfo& playerItem, Vector3 origin, Vector3 tar
 {
 	constexpr auto playerSize = LARA_RADIUS * 2.0f;
 
+	if (!g_GameFlow->GetSettings()->Gameplay.TargetObjectOcclusion)
+		return false;
+
 	auto dir = target - origin;
 	dir.Normalize();
 

--- a/TombEngine/Game/Lara/lara_fire.cpp
+++ b/TombEngine/Game/Lara/lara_fire.cpp
@@ -935,11 +935,13 @@ FireWeaponType FireWeapon(LaraWeaponType weaponType, ItemInfo* targetEntity, Ite
 
 bool IsTargetOccludedByObjects(ItemInfo& playerItem, Vector3 origin, Vector3 target, float distance)
 {
+	constexpr auto playerSize = LARA_RADIUS * 2.0f;
+
 	auto dir = target - origin;
 	dir.Normalize();
 
 	// We need to subtract Lara's radius from distance to avoid near plane false negatives.
-	distance -= LARA_RADIUS;
+	distance -= playerSize;
 
 	// Assess static mesh line of sight.
 	auto staticLos = GetStaticLosCollision(origin, playerItem.RoomNumber, dir, distance);
@@ -949,7 +951,7 @@ bool IsTargetOccludedByObjects(ItemInfo& playerItem, Vector3 origin, Vector3 tar
 		auto extents = staticLos.value().Static->GetCollisionAabb().GetExtents();
 		auto radius = Vector2(extents.x, extents.z).Length();
 
-		if (radius > LARA_RADIUS)
+		if (radius > playerSize && extents.y > playerSize)
 			return true;
 	}
 
@@ -964,7 +966,7 @@ bool IsTargetOccludedByObjects(ItemInfo& playerItem, Vector3 origin, Vector3 tar
 			auto extents = moveableLos.value().Item->GetAabb().Extents;
 			auto radius = Vector2(extents.x, extents.z).Length();
 
-			if (radius > LARA_RADIUS)
+			if (radius > playerSize && extents.y > playerSize)
 				return true;
 		}
 	}

--- a/TombEngine/Game/Lara/lara_fire.cpp
+++ b/TombEngine/Game/Lara/lara_fire.cpp
@@ -4,6 +4,7 @@
 #include "Scripting/Include/Flow/ScriptInterfaceFlowHandler.h"
 #include "Game/animation.h"
 #include "Game/camera.h"
+#include "Game/collision/Los.h"
 #include "Game/collision/Sphere.h"
 #include "Game/control/los.h"
 #include "Game/control/lot.h"
@@ -32,6 +33,7 @@
 #include "Specific/level.h"
 #include "Specific/trutils.h"
 
+using namespace TEN::Collision::Los;
 using namespace TEN::Collision::Sphere;
 using namespace TEN::Entities::Generic;
 using namespace TEN::Input;
@@ -931,6 +933,45 @@ FireWeaponType FireWeapon(LaraWeaponType weaponType, ItemInfo* targetEntity, Ite
 	}
 }
 
+bool IsTargetOccludedByObjects(ItemInfo& playerItem, Vector3 origin, Vector3 target, float distance)
+{
+	auto dir = target - origin;
+	dir.Normalize();
+
+	// We need to subtract Lara's radius from distance to avoid near plane false negatives.
+	distance -= LARA_RADIUS;
+
+	// Assess static mesh line of sight.
+	auto staticLos = GetStaticLosCollision(origin, playerItem.RoomNumber, dir, distance);
+	if (staticLos.has_value() && staticLos.value().Static != nullptr && staticLos.value().Distance < distance)
+	{
+		// Filter out statics that are too small.
+		auto extents = staticLos.value().Static->GetCollisionAabb().GetExtents();
+		auto radius = Vector2(extents.x, extents.z).Length();
+
+		if (radius > LARA_RADIUS)
+			return true;
+	}
+
+	// Assess moveable line of sight.
+	auto moveableLos = GetItemLosCollision(origin, playerItem.RoomNumber, dir, distance);
+	if (moveableLos.has_value() && moveableLos.value().Item != nullptr && moveableLos.value().Distance < distance)
+	{
+		// Don't filter out creatures.
+		if (!Objects[moveableLos.value().Item->ObjectNumber].intelligent)
+		{
+			// Filter out moveables that are too small.
+			auto extents = moveableLos.value().Item->GetAabb().Extents;
+			auto radius = Vector2(extents.x, extents.z).Length();
+
+			if (radius > LARA_RADIUS)
+				return true;
+		}
+	}
+
+	return false;
+}
+
 void FindNewTarget(ItemInfo& laraItem, const WeaponInfo& weaponInfo)
 {
 	if (!g_Configuration.EnableAutoTargeting)
@@ -944,9 +985,11 @@ void FindNewTarget(ItemInfo& laraItem, const WeaponInfo& weaponInfo)
 		return;
 	}
 
+	float muzzleOffset = GetJointPosition(&laraItem, LM_RHAND).y - laraItem.Pose.Position.y;
+
 	auto origin = GameVector(
 		laraItem.Pose.Position.x,
-		GetJointPosition(&laraItem, LM_RHAND).y, // Muzzle offset.
+		laraItem.Pose.Position.y + muzzleOffset,
 		laraItem.Pose.Position.z,
 		laraItem.RoomNumber);
 
@@ -971,14 +1014,22 @@ void FindNewTarget(ItemInfo& laraItem, const WeaponInfo& weaponInfo)
 		if (item.HitPoints <= 0)
 			continue;
 
+		// Offset target position to the same height as muzzle.
+		Vector3 pos = item.Pose.Position.ToVector3();
+		pos.y += muzzleOffset;
+
 		// Check distance.
-		float distance = Vector3::Distance(origin.ToVector3(), item.Pose.Position.ToVector3());
+		float distance = Vector3::Distance(origin.ToVector3(), pos);
 		if (distance > maxDistance)
 			continue;
 
-		// Assess line of sight.
+		// Assess room line of sight.
 		auto target = GetTargetPoint(item);
 		if (!LOS(&origin, &target))
+			continue;
+
+		// Assess occlusion by other moveables and static meshes.
+		if (IsTargetOccludedByObjects(laraItem, origin.ToVector3(), target.ToVector3(), distance))
 			continue;
 
 		// Assess whether relative orientation falls within weapon's lock constraints.

--- a/TombEngine/Game/Lara/lara_fire.cpp
+++ b/TombEngine/Game/Lara/lara_fire.cpp
@@ -950,12 +950,16 @@ bool IsTargetOccludedByObjects(ItemInfo& playerItem, Vector3 origin, Vector3 tar
 	auto staticLos = GetStaticLosCollision(origin, playerItem.RoomNumber, dir, distance);
 	if (staticLos.has_value() && staticLos.value().Static != nullptr && staticLos.value().Distance < distance)
 	{
-		// Filter out statics that are too small.
-		auto extents = staticLos.value().Static->GetCollisionAabb().GetExtents();
-		auto radius = Vector2(extents.x, extents.z).Length();
+		// Don't filter out shatterables.
+		if (Statics[staticLos.value().Static->Slot].shatterType == ShatterType::None)
+		{
+			// Filter out statics that are too small.
+			auto extents = staticLos.value().Static->GetCollisionAabb().GetExtents();
+			auto radius = Vector2(extents.x, extents.z).Length();
 
-		if (radius > playerSize && extents.y > playerSize)
-			return true;
+			if (radius > playerSize && extents.y > playerSize)
+				return true;
+		}
 	}
 
 	// Assess moveable line of sight.

--- a/TombEngine/Game/control/los.cpp
+++ b/TombEngine/Game/control/los.cpp
@@ -421,7 +421,7 @@ static bool DoRayBox(const GameVector& origin, const GameVector& target, const G
 	return true;
 }
 
-int ObjectOnLOS2(GameVector* origin, GameVector* target, Vector3i* vec, StaticMesh** staticObj, GAME_OBJECT_ID priorityObjectID, int excludedIndex)
+int ObjectOnLOS2(GameVector* origin, GameVector* target, Vector3i* vec, StaticMesh** staticObj, GAME_OBJECT_ID priorityObjectID)
 {
 	ClosestItem = NO_LOS_ITEM;
 	ClosestDist = SQUARE(target->x - origin->x) + SQUARE(target->y - origin->y) + SQUARE(target->z - origin->z);
@@ -455,9 +455,6 @@ int ObjectOnLOS2(GameVector* origin, GameVector* target, Vector3i* vec, StaticMe
 		for (int linkNumber = room.itemNumber; linkNumber != NO_VALUE; linkNumber = g_Level.Items[linkNumber].NextItem)
 		{
 			const auto& item = g_Level.Items[linkNumber];
-
-			if (item.Index == excludedIndex)
-				continue;
 
 			if (item.Status == ITEM_DEACTIVATED || item.Status == ITEM_INVISIBLE)
 				continue;

--- a/TombEngine/Game/control/los.h
+++ b/TombEngine/Game/control/los.h
@@ -13,4 +13,4 @@ constexpr auto NO_LOS_ITEM = INT_MAX;
 bool LOS(const GameVector* origin, GameVector* target);
 bool LOSAndReturnTarget(GameVector* origin, GameVector* target, int push);
 bool GetTargetOnLOS(GameVector* origin, GameVector* target);
-int	 ObjectOnLOS2(GameVector* origin, GameVector* target, Vector3i* vec, StaticMesh** mesh, GAME_OBJECT_ID priorityObjectID = GAME_OBJECT_ID::ID_NO_OBJECT, int excludedIndex = NO_VALUE);
+int	 ObjectOnLOS2(GameVector* origin, GameVector* target, Vector3i* vec, StaticMesh** mesh, GAME_OBJECT_ID priorityObjectID = GAME_OBJECT_ID::ID_NO_OBJECT);

--- a/TombEngine/Game/people.cpp
+++ b/TombEngine/Game/people.cpp
@@ -111,7 +111,7 @@ short GunShot(int x, int y, int z, short velocity, short yRot, short roomNumber)
 
 bool Targetable(ItemInfo* item, AI_INFO* ai)
 {
-	// Discard it entity is not a creature (only creatures can use Targetable()) or if the target is not visible.
+	// Discard if entity is not a creature (only creatures can use Targetable()) or if the target is not visible.
 	if (!item->IsCreature() || !ai->ahead || ai->distance >= SQUARE(MAX_VISIBILITY_DISTANCE))
 		return false;
 
@@ -139,11 +139,16 @@ bool Targetable(ItemInfo* item, AI_INFO* ai)
 		enemy->Pose.Position.z,
 		enemy->RoomNumber); // TODO: Check why this line didn't exist in the first place. -- TokyoSU 2022.08.05
 
+	// Temporarily ignore self occlusion for LOS check.
+	bool collidable = item->Collidable;
+	item->Collidable = false;
+
 	StaticMesh* mesh = nullptr;
 	Vector3i vector = {};
-	int losItemIndex = ObjectOnLOS2(&origin, &target, &vector, &mesh, GAME_OBJECT_ID::ID_NO_OBJECT, item->Index);
-	if (losItemIndex == item->Index)
-		losItemIndex = NO_LOS_ITEM; // Don't find itself.
+	int losItemIndex = ObjectOnLOS2(&origin, &target, &vector, &mesh, GAME_OBJECT_ID::ID_NO_OBJECT);
+
+	// Restore collidability.
+	item->Collidable = collidable;
 
 	return (LOS(&origin, &target) && losItemIndex == NO_LOS_ITEM && mesh == nullptr);
 }

--- a/TombEngine/Scripting/Internal/ReservedScriptNames.h
+++ b/TombEngine/Scripting/Internal/ReservedScriptNames.h
@@ -27,6 +27,7 @@ static constexpr char ScriptReserved_Statistics[]		= "Statistics";
 // Settings sections
 static constexpr char ScriptReserved_Settings[]			= "Settings";
 static constexpr char ScriptReserved_SystemSettings[]	= "System";
+static constexpr char ScriptReserved_GameplaySettings[] = "Gameplay";
 static constexpr char ScriptReserved_FlareSettings[]	= "Flare";
 static constexpr char ScriptReserved_CameraSettings[]	= "Camera";
 static constexpr char ScriptReserved_AnimSettings[]		= "Animations";

--- a/TombEngine/Scripting/Internal/TEN/Flow/Settings/Settings.cpp
+++ b/TombEngine/Scripting/Internal/TEN/Flow/Settings/Settings.cpp
@@ -41,6 +41,7 @@ namespace TEN::Scripting
 		AnimSettings::Register(parent);
 		CameraSettings::Register(parent);
 		FlareSettings::Register(parent);
+		GameplaySettings::Register(parent);
 		GraphicsSettings::Register(parent);
 		HairSettings::Register(parent);
 		HudSettings::Register(parent);
@@ -55,6 +56,7 @@ namespace TEN::Scripting
 			ScriptReserved_AnimSettings, &Settings::Animations,
 			ScriptReserved_CameraSettings, &Settings::Camera,
 			ScriptReserved_FlareSettings, &Settings::Flare,
+			ScriptReserved_GameplaySettings, &Settings::Gameplay,
 			ScriptReserved_GraphicsSettings, &Settings::Graphics,
 			ScriptReserved_HairSettings, &Settings::Hair,
 			ScriptReserved_HudSettings, &Settings::Hud,
@@ -179,6 +181,21 @@ namespace TEN::Scripting
 		/// Toggle flicker effect.
 		// @tfield bool flicker Light and lensflare flickering. When turned off, flare light will be constant.
 		"flicker", &FlareSettings::Flicker);
+	}
+
+	/// Gameplay
+	// @section Gameplay
+	// These settings are used to enable or disable certain gameplay features.
+
+	void GameplaySettings::Register(sol::table& parent)
+	{
+		parent.create().new_usertype<GameplaySettings>(ScriptReserved_GameplaySettings, sol::constructors<GameplaySettings()>(),
+			sol::call_constructor, sol::constructors<GameplaySettings()>(),
+			sol::meta_function::new_index, NewIndexErrorMaker(GameplaySettings, ScriptReserved_GameplaySettings),
+
+			/// Enable target occlusion by moveables and static meshes.
+			// @tfield bool targetObjectOcclusion If enabled, player won't be able to target enemies through moveables and static meshes.
+			"targetObjectOcclusion", & GameplaySettings::TargetObjectOcclusion);
 	}
 
 	/// Graphics

--- a/TombEngine/Scripting/Internal/TEN/Flow/Settings/Settings.h
+++ b/TombEngine/Scripting/Internal/TEN/Flow/Settings/Settings.h
@@ -50,6 +50,13 @@ namespace TEN::Scripting
 		static void Register(sol::table& parent);
 	};
 
+	struct GameplaySettings
+	{
+		bool TargetObjectOcclusion = true;
+
+		static void Register(sol::table& parent);
+	};
+
 	struct GraphicsSettings
 	{
 		bool Skinning = true;
@@ -123,6 +130,7 @@ namespace TEN::Scripting
 		AnimSettings				Animations = {};
 		CameraSettings				Camera	   = {};
 		FlareSettings				Flare	   = {};
+		GameplaySettings			Gameplay   = {};
 		GraphicsSettings			Graphics   = {};
 		std::array<HairSettings, 3> Hair	   = {};
 		HudSettings					Hud		   = {};


### PR DESCRIPTION
## Checklist

- [x] I have added a changelog entry to CHANGELOG.md file on the branch/fork (if it is an internal change then it is not needed) 
- [x] Pull request meets the Coding Conventions standards: https://github.com/MontyTRC89/TombEngine/blob/master/CONTRIBUTING.md#coding-conventions

## Links to issue(s) this pull request concerns (if applicable)

N/A

## Description of pull request 

Prevents player from targeting enemies, if they are occluded by moveables and static meshes. Moveables and static meshes with small collision boxes are ignored.