### PR TITLE
Restore Vehicle Big Splash

### DIFF
--- a/TombEngine/Objects/TR2/Vehicles/speedboat.cpp
+++ b/TombEngine/Objects/TR2/Vehicles/speedboat.cpp
@@ -782,32 +782,8 @@ namespace TEN::Entities::Vehicles
 
 	void SpeedboatSplash(ItemInfo* speedboatItem, int verticalVelocity, int water)
 	{
-		//OLD SPLASH
-		/*
-		splash_setup.x = speedboatItem->pos.x_pos;
-		splash_setup.y = water;
-		splash_setup.z = item->pos.z_pos;
-		splash_setup.InnerXZoff = 16 << 2;
-		splash_setup.InnerXZsize = 12 << 2;
-		splash_setup.InnerYsize = -96 << 2;
-		splash_setup.InnerXZvel = 0xa0;
-		splash_setup.InnerYvel = -fallspeed << 7;
-		splash_setup.InnerGravity = 0x80;
-		splash_setup.InnerFriction = 7;
-		splash_setup.MiddleXZoff = 24 << 2;
-		splash_setup.MiddleXZsize = 24 << 2;
-		splash_setup.MiddleYsize = -64 << 2;
-		splash_setup.MiddleXZvel = 0xe0;
-		splash_setup.MiddleYvel = -fallspeed << 6;
-		splash_setup.MiddleGravity = 0x48;
-		splash_setup.MiddleFriction = 8;
-		splash_setup.OuterXZoff = 32 << 2;
-		splash_setup.OuterXZsize = 32 << 2;
-		splash_setup.OuterXZvel = 0x110;
-		splash_setup.OuterFriction = 9;
-		SetupSplash(&splash_setup);
-		SplashCount = 16;
-		*/
+		// Restore the classic TR2 speedboat splash produced when it drops into water from height.
+		TriggerVehicleSplash(speedboatItem, verticalVelocity, SPEEDBOAT_RADIUS);
 	}
 
 	void SpeedboatControl(short itemNumber)
@@ -880,9 +856,10 @@ namespace TEN::Entities::Vehicles
 
 		speedboat->LeftVerticalVelocity = DoSpeedboatDynamics(heightFrontLeft, speedboat->LeftVerticalVelocity, (int*)&frontLeft.y);
 		speedboat->RightVerticalVelocity = DoSpeedboatDynamics(heightFrontRight, speedboat->RightVerticalVelocity, (int*)&frontRight.y);
-		speedboatItem->Animation.Velocity.y = DoSpeedboatDynamics(speedboat->Water, speedboatItem->Animation.Velocity.y, (int*)&speedboatItem->Pose.Position.y);
 
 		auto ofs = speedboatItem->Animation.Velocity.y;
+		speedboatItem->Animation.Velocity.y = DoSpeedboatDynamics(speedboat->Water, speedboatItem->Animation.Velocity.y, (int*)&speedboatItem->Pose.Position.y);
+
 		if (ofs - speedboatItem->Animation.Velocity.y > 32 && speedboatItem->Animation.Velocity.y == 0 && water != NO_HEIGHT)
 			SpeedboatSplash(speedboatItem, ofs - speedboatItem->Animation.Velocity.y, water);
 

--- a/TombEngine/Objects/TR3/Vehicles/kayak.cpp
+++ b/TombEngine/Objects/TR3/Vehicles/kayak.cpp
@@ -59,6 +59,7 @@ namespace TEN::Entities::Vehicles
 	constexpr auto KAYAK_DRAW_SHIFT = 32;
 	constexpr auto KAYAK_X = 128;
 	constexpr auto KAYAK_Z = 128;
+	constexpr auto KAYAK_SPLASH_RADIUS = 250;
 	constexpr auto KAYAK_MAX_KICK = -80;
 	constexpr auto KAYAK_MIN_BOUNCE = (KAYAK_VELOCITY_MAX / 2) / VEHICLE_VELOCITY_SCALE;
 
@@ -1056,6 +1057,55 @@ namespace TEN::Entities::Vehicles
 		lara->Control.Weapon.GunType = LaraWeaponType::None;
 		lara->ExtraAnim = 1;
 		lara->HitDirection = -1;
+	}
+
+	static void KayakSplash(ItemInfo* kayakItem, int verticalVelocity)
+	{
+		// Restore the classic TR3 kayak splash produced when it drops into water from height.
+		TriggerVehicleSplash(kayakItem, verticalVelocity, KAYAK_SPLASH_RADIUS);
+	}
+
+	void KayakItemControl(short itemNumber)
+	{
+		auto* kayakItem = &g_Level.Items[itemNumber];
+		auto* kayak = GetKayakInfo(kayakItem);
+
+		// While Lara drives the kayak, its tracking is handled by KayakControl() instead.
+		if (LaraItem != nullptr && GetLaraInfo(LaraItem)->Context.Vehicle == itemNumber)
+			return;
+
+		auto* laraItem = LaraItem.Get();
+
+		// Establish the water height first so a freshly dropped kayak falls onto it correctly.
+		auto probe = GetPointCollision(*kayakItem);
+		int water = GetPointCollision(kayakItem->Pose.Position, probe.GetRoomNumber()).GetWaterTopHeight();
+		if (water == NO_HEIGHT)
+		{
+			water = probe.GetFloorHeight();
+			kayak->TrueWater = false;
+		}
+		else
+		{
+			water -= 5;
+			kayak->TrueWater = true;
+		}
+		kayak->WaterHeight = water;
+
+		// Cache the vertical velocity to detect a water impact.
+		int ofs = kayakItem->Animation.Velocity.y;
+
+		KayakToBackground(kayakItem, laraItem);
+
+		// The kayak has just landed on water after a fall; spawn a splash.
+		if (ofs - kayakItem->Animation.Velocity.y > 32 &&
+			kayakItem->Animation.Velocity.y == 0 && water != NO_HEIGHT)
+		{
+			KayakSplash(kayakItem, ofs - kayakItem->Animation.Velocity.y);
+		}
+
+		probe = GetPointCollision(*kayakItem);
+		if (probe.GetRoomNumber() != kayakItem->RoomNumber)
+			ItemNewRoom(itemNumber, probe.GetRoomNumber());
 	}
 
 	bool KayakControl(ItemInfo* laraItem)

--- a/TombEngine/Objects/TR3/Vehicles/kayak.h
+++ b/TombEngine/Objects/TR3/Vehicles/kayak.h
@@ -27,4 +27,5 @@ namespace TEN::Entities::Vehicles
 	void KayakToItemCollision(ItemInfo* kayakItem, ItemInfo* laraItem);
 	void KayakLaraRapidsDrown(ItemInfo* laraItem);
 	bool KayakControl(ItemInfo* laraItem);
+	void KayakItemControl(short itemNumber);
 }

--- a/TombEngine/Objects/TR3/Vehicles/rubber_boat.cpp
+++ b/TombEngine/Objects/TR3/Vehicles/rubber_boat.cpp
@@ -489,6 +489,12 @@ namespace TEN::Entities::Vehicles
 		return verticalVelocity;
 	}
 
+	static void RubberBoatSplash(ItemInfo* rBoatItem, int verticalVelocity)
+	{
+		// Restore the classic TR3 rubber boat splash produced when it drops into water from height.
+		TriggerVehicleSplash(rBoatItem, verticalVelocity, RBOAT_RADIUS);
+	}
+
 	bool RubberBoatUserControl(ItemInfo* rBoatItem, ItemInfo* laraItem)
 	{
 		auto* rBoat = GetRubberBoatInfo(rBoatItem);
@@ -870,6 +876,9 @@ namespace TEN::Entities::Vehicles
 		rBoat->RightVerticalVelocity = DoRubberBoatDynamics(heightFrontRight, rBoat->RightVerticalVelocity, (int*)&frontRight.y);
 		ofs = rBoatItem->Animation.Velocity.y;
 		rBoatItem->Animation.Velocity.y = DoRubberBoatDynamics(rBoat->Water, rBoatItem->Animation.Velocity.y, (int*)&rBoatItem->Pose.Position.y);
+
+		if (ofs - rBoatItem->Animation.Velocity.y > 32 && rBoatItem->Animation.Velocity.y == 0 && water != NO_HEIGHT)
+			RubberBoatSplash(rBoatItem, ofs - rBoatItem->Animation.Velocity.y);
 
 		height = frontLeft.y + frontRight.y;
 		if (height < 0)

--- a/TombEngine/Objects/TR3/tr3_objects.cpp
+++ b/TombEngine/Objects/TR3/tr3_objects.cpp
@@ -850,6 +850,7 @@ static void StartVehicles(ObjectInfo* obj)
 	if (obj->loaded)
 	{
 		obj->Initialize = InitializeKayak;
+		obj->control = KayakItemControl;
 		obj->collision = KayakPlayerCollision;
 		obj->shadowType = ShadowMode::Player;
 		obj->SetHitEffect(true);

--- a/TombEngine/Objects/Utils/VehicleHelpers.cpp
+++ b/TombEngine/Objects/Utils/VehicleHelpers.cpp
@@ -434,6 +434,23 @@ namespace TEN::Entities::Vehicles
 		g_Hud.Speedometer.UpdateValue(value);
 	}
 
+	void TriggerVehicleSplash(ItemInfo* vehicleItem, float fallVelocity, float splashRadius)
+	{
+		auto pointColl = GetPointCollision(*vehicleItem);
+		int room = pointColl.GetRoomNumber();
+
+		int waterHeight = GetPointCollision(vehicleItem->Pose.Position, room).GetWaterTopHeight();
+		if (waterHeight == NO_HEIGHT)
+			return;
+
+		// Spawn a splash at the water's surface proportional to the fall velocity, mimicking the
+		// large splash legacy TR3 boats produced when dropped from a winch into the water.
+		SplashSetup.Position = Vector3(vehicleItem->Pose.Position.x, waterHeight - 1, vehicleItem->Pose.Position.z);
+		SplashSetup.SplashPower = fallVelocity * 4.0f;
+		SplashSetup.InnerRadius = splashRadius;
+		SetupSplash(&SplashSetup, room);
+	}
+
 	void UpdateVehicleRoom(ItemInfo* vehicleItem, ItemInfo* laraItem, int currentRoomNumber)
 	{
 		if (vehicleItem == nullptr)

--- a/TombEngine/Objects/Utils/VehicleHelpers.h
+++ b/TombEngine/Objects/Utils/VehicleHelpers.h
@@ -44,6 +44,7 @@ namespace TEN::Entities::Vehicles
 	void  ResetVehicleLean(ItemInfo* vehicleItem, float rate);
 
 	void SpawnVehicleWake(const ItemInfo& vehicleItem, const Vector3& relOffset, int waterHeight, bool isUnderwater = false);
+	void TriggerVehicleSplash(ItemInfo* vehicleItem, float fallVelocity, float splashRadius);
 	void HandleVehicleSpeedometer(float vel, float velMax);
 	void UpdateVehicleRoom(ItemInfo* vehicleItem, ItemInfo* laraItem = nullptr, int currentRoomNumber = NO_VALUE);
 }


### PR DESCRIPTION
This pull request restores the classic water splash effects for vehicles (speedboat, kayak, and rubber boat) when they drop into water from a height, closely mimicking the original TR2 and TR3 game behavior. It introduces a unified helper function to handle splash generation and ensures each vehicle triggers the effect at the appropriate time.

**Restoration of Classic Vehicle Splash Effects:**

* Introduced a new `TriggerVehicleSplash` helper function in `VehicleHelpers.cpp`/`.h` to centralize and standardize splash effect spawning for vehicles, scaling splash size and power based on fall velocity and vehicle type. [[1]](diffhunk://#diff-c40c40e886ef0529be6b38fe0d1f89d20ee3310135e96fdddc53833469ff8af7R437-R453) [[2]](diffhunk://#diff-ad1e7a960fee50d08094ca4a7f68c2d9021fd70a0e47ff30cae6f2370a035934R47)
* Updated the speedboat (`speedboat.cpp`), kayak (`kayak.cpp`), and rubber boat (`rubber_boat.cpp`) logic to call `TriggerVehicleSplash` when the vehicle lands on water after a fall, restoring the original TR2/TR3 splash visuals. [[1]](diffhunk://#diff-c4dc29e8232b8a3f49a4a18c46ac9d01d6299d9e6258f9fa2fcf2c191f969ca8L785-R786) [[2]](diffhunk://#diff-665181caa6e6fb09f725d654306d84b9199a2a04fa61eb999713f7008212b15fR1065-R1113) [[3]](diffhunk://#diff-2a181d822c9089388e4c99640d9c8c7a5ef09eb4ea00a6c99608c5952a613d1cR492-R497) [[4]](diffhunk://#diff-2a181d822c9089388e4c99640d9c8c7a5ef09eb4ea00a6c99608c5952a613d1cR880-R882)

**Kayak Vehicle Control Improvements:**

* Added a new `KayakItemControl` function to handle kayak state and splash triggering when not directly controlled by the player, and registered it in the kayak initialization. [[1]](diffhunk://#diff-665181caa6e6fb09f725d654306d84b9199a2a04fa61eb999713f7008212b15fR1065-R1113) [[2]](diffhunk://#diff-07f5f076478863c608046d4a59ccd7e183776f480168ae09ee73cf34180167d3R30) [[3]](diffhunk://#diff-dbcfff7a92c5fc6d91a92c757c416b29ef7d7eade6b486205ff1d683185a715aR853)
* Defined a new constant `KAYAK_SPLASH_RADIUS` to control the splash size for the kayak.

These changes improve visual feedback and authenticity for vehicle-water interactions, aligning the engine's behavior with the original games.

## To test

* Place any boat (Kayak / Rubber or Speed) above water and trigger it. It should fall and create a big splash.
* Big splash will also generate if player is riding it and falls from height.

## Engine

[Bin.zip](https://github.com/user-attachments/files/31118546/Bin.zip)
