### PR TITLE
Fix underwater transition into dry rooms

### DIFF
--- a/TombEngine/Game/Lara/lara_tests.cpp
+++ b/TombEngine/Game/Lara/lara_tests.cpp
@@ -1109,7 +1109,8 @@ void TestLaraWaterDepth(ItemInfo* item, CollisionInfo* coll)
 		item->Animation.Velocity.y = 0.0f;
 		item->Pose.Position = coll->Setup.PrevPosition;
 	}
-	else if (pointColl.GetWaterBottomHeight() <= (LARA_HEIGHT - (LARA_HEADROOM / 2)))
+	else if (TestEnvironment(ENV_FLAG_WATER, pointColl.GetRoomNumber()) &&
+		pointColl.GetWaterBottomHeight() <= (LARA_HEIGHT - (LARA_HEADROOM / 2)))
 	{
 		SetAnimation(item, LA_UNDERWATER_TO_STAND);
 		ResetPlayerLean(item);


### PR DESCRIPTION
 **The bug with the transition from the dry room to the shallows water.**

This bug occurs in waterfall setups, where the sink push her from the water room to the dry room. As you can see in the video, Lara teleport to the floor under the waterfall instead of falling.
<img width="1091" height="888" alt="2026-08-30_19-17-10" src="https://github.com/user-attachments/assets/3e19571c-5492-4ebf-bde8-9a1f62862f42" />



https://github.com/user-attachments/assets/b6f3de92-8d2c-403d-a193-b37f052bae62


The reason is that the `TestLaraWaterDepth()` function snaps Lara to the shallow water floor and starts the `LA_UNDERWATER_TO_STAND` animation, cause of late item->RoomNumber update.

The solution is just add `TestEnvironment(ENV_FLAG_WATER)` condition to the `TestLaraWaterDepth()`, so Lara can't transition from the water to shallow water without physically being in the water. 