### PR TITLE
Allow fractional radii for scripted lights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,7 +139,7 @@ TombEngine releases are located in this repository (alongside with Tomb Editor):
 * Added `Objects.GetMaterialByName` and `Objects.GetMaterialsByObject` functions.
 * Added `Moveable:GetProperty`, `Moveable:SetProperty` and `Moveable:HasInstanceProperty` functions.
 * Added `Static:GetProperty`, `Static:SetProperty` and `Static:HasInstanceProperty` functions.
-* Updated `EmitLight()`, EmitSpotLight() and `EmitFogBulb` to accept fractional ranges, allowing the radius to be smoothly scaled.
+* Updated `EmitLight()`, `EmitSpotLight()` and `EmitFogBulb()` to accept fractional values, allowing smooth scaling of radius/falloff/distance.
 * Removed `View.SetPostProcessMode` and `View.SetPostProcessStrength` functions superseded by `View.SetPostProcess` method.
 * Renamed `ENTER`, `INSIDE` and `LEAVE` entries in `Logic.EventType` enum to `VOLUME_ENTER`, `VOLUME_INSIDE` and `VOLUME_LEAVE`.
 * Renamed `Snow`, `Rain` and `None` entries in `Flow.WeatherType` enum to `SNOW`, `RAIN` and `NONE`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,7 @@ TombEngine releases are located in this repository (alongside with Tomb Editor):
 * Added `Objects.GetMaterialByName` and `Objects.GetMaterialsByObject` functions.
 * Added `Moveable:GetProperty`, `Moveable:SetProperty` and `Moveable:HasInstanceProperty` functions.
 * Added `Static:GetProperty`, `Static:SetProperty` and `Static:HasInstanceProperty` functions.
+* Updated `EmitLight()`, EmitSpotLight() and `EmitFogBulb` to accept fractional ranges, allowing the radius to be smoothly scaled.
 * Removed `View.SetPostProcessMode` and `View.SetPostProcessStrength` functions superseded by `View.SetPostProcess` method.
 * Renamed `ENTER`, `INSIDE` and `LEAVE` entries in `Logic.EventType` enum to `VOLUME_ENTER`, `VOLUME_INSIDE` and `VOLUME_LEAVE`.
 * Renamed `Snow`, `Rain` and `None` entries in `Flow.WeatherType` enum to `SNOW`, `RAIN` and `NONE`.

--- a/TombEngine/Game/effects/Light.cpp
+++ b/TombEngine/Game/effects/Light.cpp
@@ -22,8 +22,8 @@ namespace TEN::Effects::Light
 		g_Renderer.AddDynamicPointLight(Vector3(x, y, z), float(falloff * UCHAR_MAX), Color(r / (float)UCHAR_MAX, g / (float)UCHAR_MAX, b / (float)UCHAR_MAX), false);
 	}
 
-	void SpawnDynamicFogBulb(const Vector3& pos, short radius, short density, const Color& color, int hash)
+	void SpawnDynamicFogBulb(const Vector3& pos, float radius, short density, const Color& color, int hash)
 	{
-		g_Renderer.AddDynamicFogBulb(pos, float(radius * UCHAR_MAX), float(density / (float)UCHAR_MAX), color, hash);
+		g_Renderer.AddDynamicFogBulb(pos, radius * UCHAR_MAX, float(density / (float)UCHAR_MAX), color, hash);
 	}
 }

--- a/TombEngine/Game/effects/Light.cpp
+++ b/TombEngine/Game/effects/Light.cpp
@@ -24,6 +24,6 @@ namespace TEN::Effects::Light
 
 	void SpawnDynamicFogBulb(const Vector3& pos, float radius, short density, const Color& color, int hash)
 	{
-		g_Renderer.AddDynamicFogBulb(pos, radius * UCHAR_MAX, float(density / (float)UCHAR_MAX), color, hash);
+		g_Renderer.AddDynamicFogBulb(pos, radius * CLICK(1), float(density / (float)UCHAR_MAX), color, hash);
 	}
 }

--- a/TombEngine/Game/effects/Light.h
+++ b/TombEngine/Game/effects/Light.h
@@ -4,7 +4,7 @@ namespace TEN::Effects::Light
 {
 	void SpawnDynamicPointLight(const Vector3& pos, const Color& color, float falloff, bool castShadows = false, int hash = 0);
 	void SpawnDynamicSpotLight(const Vector3& pos, const Vector3& dir, const Color& color, float radius, float falloff, float dist, bool castShadows = false, int hash = 0);
-	void SpawnDynamicFogBulb(const Vector3& pos, short radius, short density, const Color& color, int hash = 0);
+	void SpawnDynamicFogBulb(const Vector3& pos, float radius, short density, const Color& color, int hash = 0);
 	
 	// DEPRECATED!!! Use SpawnDynamicPointLight() instead and phase out this legacy function.
 	void SpawnDynamicLight(int x, int y, int z, short falloff, unsigned char r, unsigned char g, unsigned char b);

--- a/TombEngine/Objects/TR3/Trap/FirePendulum.cpp
+++ b/TombEngine/Objects/TR3/Trap/FirePendulum.cpp
@@ -19,7 +19,7 @@ using namespace TEN::Scripting::Properties;
 namespace TEN::Entities::Traps
 {
 	constexpr auto PENDULUM_FIRE_FOG_DENSITY   = 15;
-	constexpr auto PENDULUM_FIRE_FOG_RADIUS    = 4; // Clicks; SpawnDynamicFogBulb converts to world units (x UCHAR_MAX).
+	constexpr auto PENDULUM_FIRE_FOG_RADIUS    = 4; // Clicks; SpawnDynamicFogBulb converts to world units (radius * CLICK(1)).
 	constexpr auto PENDULUM_FLAME_SPARK_LENGTH = 80;
 	constexpr auto PENDULUM_FLAME_SPARK_COUNT  = 3;
 	constexpr auto PENDULUM_FLAME_SPARK_SPREAD = 48;

--- a/TombEngine/Objects/TR3/Trap/FirePendulum.cpp
+++ b/TombEngine/Objects/TR3/Trap/FirePendulum.cpp
@@ -19,7 +19,7 @@ using namespace TEN::Scripting::Properties;
 namespace TEN::Entities::Traps
 {
 	constexpr auto PENDULUM_FIRE_FOG_DENSITY   = 15;
-	constexpr auto PENDULUM_FIRE_FOG_RADIUS    = 4;
+	constexpr auto PENDULUM_FIRE_FOG_RADIUS    = 4; // Clicks; SpawnDynamicFogBulb converts to world units (x UCHAR_MAX).
 	constexpr auto PENDULUM_FLAME_SPARK_LENGTH = 80;
 	constexpr auto PENDULUM_FLAME_SPARK_COUNT  = 3;
 	constexpr auto PENDULUM_FLAME_SPARK_SPREAD = 48;

--- a/TombEngine/Scripting/Internal/TEN/Effects/EffectsFunctions.cpp
+++ b/TombEngine/Scripting/Internal/TEN/Effects/EffectsFunctions.cpp
@@ -462,13 +462,13 @@ namespace TEN::Scripting::Effects
 	// @function EmitLight
 	// @tparam Vec3 pos World position of the light.
 	// @tparam[opt=Color(255&#44; 255&#44; 255)] Color color Light color.
-	// @tparam[opt=20] int radius Measured in "clicks" or 256 world units.
+	// @tparam[opt=20] float radius Light radius in clicks (256 world units per click). Accepts fractional values for smooth resizing.
 	// @tparam[opt=false] bool shadows Determines whether light should generate dynamic shadows for applicable moveables.
 	// @tparam[opt] string name If provided, engine will interpolate this light for high framerate mode (be careful not to use same name for different lights).
-	static void EmitLight(Vec3 pos, TypeOrNil<ScriptColor> col, TypeOrNil<int> radius, TypeOrNil<bool> castShadows, TypeOrNil<std::string> name)
+	static void EmitLight(Vec3 pos, TypeOrNil<ScriptColor> col, TypeOrNil<float> radius, TypeOrNil<bool> castShadows, TypeOrNil<std::string> name)
 	{
 		auto color = ValueOr<ScriptColor>(col, ScriptColor(255, 255, 255)).PremultiplyAlpha();
-		int rad = (float)(ValueOr<int>(radius, 20) * BLOCK(0.25f));
+		float rad = ValueOr<float>(radius, 20.0f) * CLICK(1);
 		SpawnDynamicPointLight(pos.ToVector3(), color, rad, ValueOr<bool>(castShadows, false), GetHash(ValueOr<std::string>(name, std::string())));
 	}
 
@@ -478,17 +478,17 @@ namespace TEN::Scripting::Effects
 	// @tparam Vec3 pos World position of the light.
 	// @tparam Vec3 dir Normal which indicates light direction.
 	// @tparam[opt=Color(255&#44; 255&#44; 255)] Color color Light color.
-	// @tparam[opt=10] int radius Overall radius at the endpoint of a light cone, measured in "clicks" or 256 world units.
-	// @tparam[opt=5] int falloff Radius, at which light starts to fade out, measured in "clicks".
-	// @tparam[opt=20] int distance Distance, at which light cone fades out, measured in "clicks".
+	// @tparam[opt=10] float radius Overall radius of the light cone in clicks (256 world units per click). Accepts fractional values.
+	// @tparam[opt=5] float falloff Radius, at which light starts to fade out, in clicks (256 world units per click). Accepts fractional values.
+	// @tparam[opt=20] float distance Distance, at which light cone fades out, in clicks (256 world units per click). Accepts fractional values.
 	// @tparam[opt=false] bool shadows Determines whether light should generate dynamic shadows for applicable moveables.
 	// @tparam[opt] string name If provided, engine will interpolate this light for high framerate mode (be careful not to use same name for different lights).
-	static void EmitSpotLight(Vec3 pos, Vec3 dir, TypeOrNil<ScriptColor> col, TypeOrNil<int> radius, TypeOrNil<int> falloff, TypeOrNil<int> distance, TypeOrNil<bool> castShadows, TypeOrNil<std::string> name)
+	static void EmitSpotLight(Vec3 pos, Vec3 dir, TypeOrNil<ScriptColor> col, TypeOrNil<float> radius, TypeOrNil<float> falloff, TypeOrNil<float> distance, TypeOrNil<bool> castShadows, TypeOrNil<std::string> name)
 	{
 		auto color = ValueOr<ScriptColor>(col, ScriptColor(255, 255, 255)).PremultiplyAlpha();
-		int rad =	  (float)(ValueOr<int>(radius,   10) * BLOCK(0.25f));
-		int fallOff = (float)(ValueOr<int>(falloff,   5) * BLOCK(0.25f));
-		int dist =	  (float)(ValueOr<int>(distance, 20) * BLOCK(0.25f));
+		float rad = ValueOr<float>(radius,   10.0f) * CLICK(1);
+		float fallOff = ValueOr<float>(falloff,   5.0f) * CLICK(1);
+		float dist = ValueOr<float>(distance, 20.0f) * CLICK(1);
 		SpawnDynamicSpotLight(pos.ToVector3(), dir.ToVector3(), color, rad, fallOff, dist, ValueOr<bool>(castShadows, false), GetHash(ValueOr<std::string>(name, std::string())));
 	}
 
@@ -496,16 +496,16 @@ namespace TEN::Scripting::Effects
 	// If you want a fog bulb that sticks around, you must call this each frame.
 	// @function EmitFogBulb
 	// @tparam Vec3 pos Position of the fog bulb.
-	// @tparam[opt=20] int radius Radius measured in "clicks" or 256 world units.
+	// @tparam[opt=20] float radius Fog bulb radius in clicks (256 world units per click). Accepts fractional values for smooth resizing.
 	// @tparam[opt=255] int density Density, ranging from 0 to 255.
 	// @tparam[opt=Color(255&#44; 255&#44; 255)] Color color Color.
 	// @tparam[opt] string name If provided, engine will interpolate this fog bulb for high framerate mode (be careful not to use same name for different fogbulbs)
-	static void EmitFogBulb(Vec3 pos, TypeOrNil<int> radius, TypeOrNil<int> density, TypeOrNil<ScriptColor> col, TypeOrNil<std::string> name)
+	static void EmitFogBulb(Vec3 pos, TypeOrNil<float> radius, TypeOrNil<int> density, TypeOrNil<ScriptColor> col, TypeOrNil<std::string> name)
 	{
 		constexpr auto DEFAULT_DENSITY = 255;
 
 		auto color = ValueOr<ScriptColor>(col, ScriptColor(255, 255, 255)).PremultiplyAlpha();
-		int rad = (float)(ValueOr<int>(radius, 20));
+		float rad = ValueOr<float>(radius, 20.0f);
 		int dens = (float)(ValueOr<int>(density, DEFAULT_DENSITY));
 		SpawnDynamicFogBulb(pos.ToVector3(), rad, dens, color, GetHash(ValueOr<std::string>(name, std::string())));
 	}

--- a/TombEngine/Scripting/Internal/TEN/Effects/EffectsFunctions.cpp
+++ b/TombEngine/Scripting/Internal/TEN/Effects/EffectsFunctions.cpp
@@ -462,7 +462,7 @@ namespace TEN::Scripting::Effects
 	// @function EmitLight
 	// @tparam Vec3 pos World position of the light.
 	// @tparam[opt=Color(255&#44; 255&#44; 255)] Color color Light color.
-	// @tparam[opt=20] float radius Light radius in clicks (256 world units per click). Accepts fractional values for smooth resizing.
+	// @tparam[opt=20] float radius Light radius in clicks (256 world units per click). Accepts fractional values.
 	// @tparam[opt=false] bool shadows Determines whether light should generate dynamic shadows for applicable moveables.
 	// @tparam[opt] string name If provided, engine will interpolate this light for high framerate mode (be careful not to use same name for different lights).
 	static void EmitLight(Vec3 pos, TypeOrNil<ScriptColor> col, TypeOrNil<float> radius, TypeOrNil<bool> castShadows, TypeOrNil<std::string> name)
@@ -486,8 +486,8 @@ namespace TEN::Scripting::Effects
 	static void EmitSpotLight(Vec3 pos, Vec3 dir, TypeOrNil<ScriptColor> col, TypeOrNil<float> radius, TypeOrNil<float> falloff, TypeOrNil<float> distance, TypeOrNil<bool> castShadows, TypeOrNil<std::string> name)
 	{
 		auto color = ValueOr<ScriptColor>(col, ScriptColor(255, 255, 255)).PremultiplyAlpha();
-		float rad = ValueOr<float>(radius,   10.0f) * CLICK(1);
-		float fallOff = ValueOr<float>(falloff,   5.0f) * CLICK(1);
+		float rad = ValueOr<float>(radius, 10.0f) * CLICK(1);
+		float fallOff = ValueOr<float>(falloff, 5.0f) * CLICK(1);
 		float dist = ValueOr<float>(distance, 20.0f) * CLICK(1);
 		SpawnDynamicSpotLight(pos.ToVector3(), dir.ToVector3(), color, rad, fallOff, dist, ValueOr<bool>(castShadows, false), GetHash(ValueOr<std::string>(name, std::string())));
 	}
@@ -496,7 +496,7 @@ namespace TEN::Scripting::Effects
 	// If you want a fog bulb that sticks around, you must call this each frame.
 	// @function EmitFogBulb
 	// @tparam Vec3 pos Position of the fog bulb.
-	// @tparam[opt=20] float radius Fog bulb radius in clicks (256 world units per click). Accepts fractional values for smooth resizing.
+	// @tparam[opt=20] float radius Fog bulb radius in clicks (256 world units per click). Accepts fractional values.
 	// @tparam[opt=255] int density Density, ranging from 0 to 255.
 	// @tparam[opt=Color(255&#44; 255&#44; 255)] Color color Color.
 	// @tparam[opt] string name If provided, engine will interpolate this fog bulb for high framerate mode (be careful not to use same name for different fogbulbs)


### PR DESCRIPTION
Updated the effects API and implementation to use `float` radii for emitted point lights, spot lights, and fog bulbs, enabling smooth fractional sizing from Lua scripts. Radius/falloff/distance conversion now consistently uses click-based world units (`CLICK(1)`), `SpawnDynamicFogBulb` now accepts a float radius, and related Lua docs/comments were updated to reflect fractional click support.

* API changes are backwards compatible
* Allows Lua-spawned point/spot/fog lights to be resized smoothly, rather than snapping to click radii of 256 units.
  - Fog bulbs still aren't 100% smooth as the radius "latches" onto room vertices, but the fog now does scale better than on `develop`

## Testing

* Lua spawned lights have no visual change (tested and confirmed already)

## Sample code

```Lua
  LevelFuncs.EmitPoint = function()
  EmitLight((Lara:GetJointPosition(14) + Vec3(0,-256,0)),TEN.Color(255,0,0), 22.3, true, "lara_light")
  end
```
## Engine files
_Un-zip and place (accepting overwrite) inside your `Engine` folder._
[LightRadiusUnbound.zip](https://github.com/user-attachments/files/31695389/LightRadiusUnbound.zip)

## Checklist

- [x] I have added a changelog entry to the `CHANGELOG.md` file on the branch/fork (if it is an internal change, this is not needed).
- [x] This pull request meets the Coding Conventions standards: https://github.com/MontyTRC89/TombEngine/blob/master/CONTRIBUTING.md#coding-conventions

**Required for updated Tomb Editor node https://github.com/TombEngine/Tomb-Editor/pull/1279**
